### PR TITLE
Add ES256K into supported algorithm

### DIFF
--- a/lib/src/jwa.dart
+++ b/lib/src/jwa.dart
@@ -66,6 +66,7 @@ class JsonWebAlgorithm {
     es256,
     es384,
     es512,
+    es256k,
 /*
     ps256,
     ps384,
@@ -120,6 +121,10 @@ class JsonWebAlgorithm {
   /// ECDSA using P-521 and SHA-512
   static const es512 =
       JsonWebAlgorithm('ES512', type: 'EC', use: 'sig', curve: 'P-521');
+
+  /// ECDSA using P-256K and SHA-256
+  static const es256k =
+      JsonWebAlgorithm('ES256K', type: 'EC', use: 'sig', curve: 'P-256K');
 
 /* TODO: not supported yet in crypto_keys
   /// RSASSA-PSS using SHA-256 and MGF1 with SHA-256

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/heacare/jose
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+
 dependencies:
-  crypto_keys: '>=0.2.0 <0.4.0'
   meta: ^1.1.6
   typed_data: ^1.0.0
   x509: ^0.2.1
@@ -15,6 +15,12 @@ dependencies:
   http_parser: ^4.0.0
   asn1lib: ^1.0.0
   collection: ^1.15.0
+    
+dependency_overrides:
+  crypto_keys:
+    git:
+      url: https://github.com/muhammadsaddamnur/crypto_keys.git
+      ref: master 
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
I was trying to implement JOSE/JWT using `ES256K` algorithm using this library, which listed as supported signing algo JWS on it's README. But, turns out it did not work and give me error that algo is not supported. I tried to dig out on the source code and found that the algo is not listed on the library and also in this library that listed as it's dependency. I also found out that change also needed on (crypto_keys) [https://github.com/appsup-dart/crypto_keys](https://github.com/appsup-dart/crypto_keys) that listed as dependency. 

For this PR I'm pointing the dependency to my fork for temporary workaround, and once (this PR)  [https://github.com/appsup-dart/crypto_keys/pull/11](https://github.com/appsup-dart/crypto_keys/pull/11) merged and released, we can update the dependency.

Please review! Thank you